### PR TITLE
Admin functionality

### DIFF
--- a/app/controllers/users/base_controller.rb
+++ b/app/controllers/users/base_controller.rb
@@ -8,6 +8,7 @@ private
   end
 
   def authorized?
+    return true if current_admin?
     return true if folder_authed?
     return true if personal_asset?
     return false

--- a/app/helpers/admins_helper.rb
+++ b/app/helpers/admins_helper.rb
@@ -10,7 +10,7 @@ module AdminsHelper
     if user.active?
       button_to 'Disable', admin_users_path(current_user, user_id: user.id, user: { status: "inactive"}), method: :patch, class: "btn btn-danger"
     else
-      button_to 'Enable', admin_users_path(current_user, user_id: user.id, user: { status: "inactive"}), method: :patch, class: "btn btn-info"
+      button_to 'Enable', admin_users_path(current_user, user_id: user.id, user: { status: "active"}), method: :patch, class: "btn btn-info"
     end
   end
 end

--- a/app/views/users/folders/show.html.erb
+++ b/app/views/users/folders/show.html.erb
@@ -14,7 +14,7 @@
           <th>Status</th>
           <th></th>
           <% @current_folder.folders.each do |folder|%>
-            <tr>
+            <tr class="folder">
               <td> <%= link_to folder.name, "#{folder.url}"%></td>
               <td>  Folder </td>
               <td> <%=folder.updated_at%></td>
@@ -27,7 +27,7 @@
         </div>
         <div class="binaries">
           <% @current_folder.binaries.each do |binary|%>
-            <tr>
+            <tr class="binary">
               <td> <%=link_to(binary.name, binary.url)%></td>
               <td> <%=binary.extension%></td>
               <td> <%=binary.updated_at%></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -15,7 +15,7 @@
     <div class="<%=user.username%>">
       <tr>
       <td> <img src=" <%=user.avatar_url%>" class="img-thumbnail" width="30%" alt="User's Profile"></td>
-      <td><%=user.username%></td>
+      <td><%=link_to user.username, users_folder_path(user.username, route: "home") %></td>
       <td><%=user.name%></td>
       <td><%=user.email%></td>
       <td><%=user.phone%></td>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,15 +29,4 @@
   n += 1
 end
 
-User.new(name: Faker::LordOfTheRings.character,
-        username: "admin1",
-        email: Faker::Internet.email,
-        phone: '5555555555',
-        status: 'active',
-        token: Faker::Internet.password,
-        password: "password",
-        role: "admin",
-        avatar_url: 'https://thumb.ibb.co/htakav/default_profile.jpg').save(validate: false)
-
-user = User.last
-user.owned_folders.new(name: 'home', route: 'home', slug: 'home').save(validate: false)
+User.last.update(name: 'Gandalf', role:'admin1').save(validate: false)

--- a/spec/features/admins/admin_can_change_users_status_spec.rb
+++ b/spec/features/admins/admin_can_change_users_status_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+require 'helpers/admin_helper'
+
+RSpec.feature "Admin can change a user's status" do
+  context "As an Admin on admin index page" do
+    scenario "Admin can disable a user" do
+      stub_admin
+      user = create(:user)
+      visit admin_users_path(@admin)
+
+      within(".#{user.username}") do
+        expect(page).to have_content("active")
+        expect(page).to have_button("Disable")
+        click_on("Disable")
+      end
+
+      visit admin_users_path(@admin)
+
+      within(".#{user.username}") do
+        expect(page).to have_content("inactive")
+        expect(page).to have_button("Enable")
+      end
+
+      expect(User.last.status).to eq("inactive")
+    end
+
+    scenario "Admin can disable a user" do
+      stub_admin
+      user = create(:inactive_user)
+      visit admin_users_path(@admin)
+
+      within(".#{user.username}") do
+        expect(page).to have_content("inactive")
+        expect(page).to have_button("Enable")
+        click_on("Enable")
+      end
+
+      visit admin_users_path(@admin)
+
+      within(".#{user.username}") do
+        expect(page).to have_content("active")
+        expect(page).to have_button("Disable")
+      end
+
+      expect(User.last.status).to eq("active")
+    end
+  end
+end

--- a/spec/features/admins/admin_can_delete_spec.rb
+++ b/spec/features/admins/admin_can_delete_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+require 'helpers/admin_helper'
+
+
+RSpec.feature "Admin can delete items" do
+  xcontext "As an Admin" do
+    scenario "admin can delete user's folder" do
+      stub_admin
+      user = create(:user_with_folders)
+      expect(user.home.folders.count).to eq(3)
+      visit "/#{user.username}/home"
+      save_and_open_page
+
+      expect{ within(".folder") do
+                click_on "Delete"
+              end
+              click_on "OK"
+      }.to change{user.home.folders.count}.from(3).to(2)
+
+    expect(current_path).to eq("/#{user.username}/home")
+    expect(page).to have_content("Successfully Deleted!")
+    end
+
+    scenario "admin can delete user's file" do
+      stub_admin
+      user = create(:user_with_folders)
+
+      expect(user.home.folders.count).to eq(3)
+      visit "/#{user.username}/home"
+
+      expect{ within(".binary") do
+                click_on "Delete"
+              end
+              click_on "OK"
+      }.to change{user.home.binaries.count}.from(3).to(2)
+
+    expect(current_path).to eq("/#{user.username}/home")
+    expect(page).to have_content("Successfully Deleted!")
+    end
+  end
+end

--- a/spec/features/admins/admin_can_delete_spec.rb
+++ b/spec/features/admins/admin_can_delete_spec.rb
@@ -1,20 +1,17 @@
 require 'rails_helper'
 require 'helpers/admin_helper'
 
-
 RSpec.feature "Admin can delete items" do
-  xcontext "As an Admin" do
+  context "As an Admin" do
     scenario "admin can delete user's folder" do
       stub_admin
       user = create(:user_with_folders)
       expect(user.home.folders.count).to eq(3)
       visit "/#{user.username}/home"
-      save_and_open_page
 
-      expect{ within(".folder") do
+      expect{ within(first(".folder")) do
                 click_on "Delete"
               end
-              click_on "OK"
       }.to change{user.home.folders.count}.from(3).to(2)
 
     expect(current_path).to eq("/#{user.username}/home")
@@ -28,10 +25,9 @@ RSpec.feature "Admin can delete items" do
       expect(user.home.folders.count).to eq(3)
       visit "/#{user.username}/home"
 
-      expect{ within(".binary") do
+      expect{ within(first(".binary")) do
                 click_on "Delete"
               end
-              click_on "OK"
       }.to change{user.home.binaries.count}.from(3).to(2)
 
     expect(current_path).to eq("/#{user.username}/home")

--- a/spec/features/admins/admin_can_see_all_users_spec.rb
+++ b/spec/features/admins/admin_can_see_all_users_spec.rb
@@ -1,13 +1,11 @@
 require 'rails_helper'
-
+require 'helpers/admin_helper'
 
 RSpec.feature "Admin can see all users" do
   context "As a logged in Admin" do
 
     before :each do
-      @admin = create(:admin)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
-        #make a current_admin method?
+      stub_admin
     end
 
     scenario "Admin can visit users#index and see all users" do

--- a/spec/helpers/admin_helper.rb
+++ b/spec/helpers/admin_helper.rb
@@ -1,0 +1,4 @@
+  def stub_admin
+    @admin = create(:admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+  end


### PR DESCRIPTION
@case-eee 

Last of admin functionality user story.

User stories:
Admins are able to view a full index of all users, along with their profile pictures, names, emails, etc.
Admins can enable users.
Admins can disable users.
Admins can make users admins
Admins can make other admins back into default users.
Admins can click on a user's name to view and delete their folders and files.